### PR TITLE
show optional toggle if `optional` is enabled

### DIFF
--- a/client/ayon_jira/plugins/publish/collect_jira_notifications.py
+++ b/client/ayon_jira/plugins/publish/collect_jira_notifications.py
@@ -4,11 +4,11 @@ import pyblish.api
 
 from ayon_core.lib.profiles_filtering import filter_profiles
 from ayon_core.lib import attribute_definitions
-from ayon_core.pipeline import AYONPyblishPluginMixin
+from ayon_core.pipeline import OptionalPyblishPluginMixin
 
 
 class CollectJiraNotifications(pyblish.api.InstancePlugin,
-                               AYONPyblishPluginMixin):
+                               OptionalPyblishPluginMixin):
     """Collects login credentials for Jira"""
     order = pyblish.api.CollectorOrder
     label = "Collect Jira Notifications"
@@ -18,7 +18,8 @@ class CollectJiraNotifications(pyblish.api.InstancePlugin,
 
     @classmethod
     def get_attribute_defs(cls):
-        return [
+        attrs = super().get_attribute_defs()
+        return attrs + [
             attribute_definitions.TextDef(
                 # Key under which it will be stored
                 "additional_message",


### PR DESCRIPTION
## Changelog Description
Fix issue where optional toggle was not shown when enabling it in settings.

![image](https://github.com/user-attachments/assets/23a8f34e-ac8d-4beb-9f07-b5d59aafaf46)


## Testing notes:

1. Enable: `ayon+settings://jira/publish/CollectJiraNotifications/optional`
2. Open your favorite DCC and you should be able to see the plugin toggle in the publisher UI.
