### PR TITLE
Moved jira dependency to runtime

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
+
+[ayon.runtimeDependencies]
 atlassian-python-api = "^3.41.14"
 
 [build-system]


### PR DESCRIPTION
## Changelog Description
Jira dependencies should be only runtime



